### PR TITLE
Removing compiler warning

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -7,10 +7,6 @@ use std::process::exit;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use syntect::easy::HighlightLines;
-use syntect::highlighting::{Style, ThemeSet};
-use syntect::parsing::SyntaxSet;
-use syntect::util::{as_24_bit_terminal_escaped, LinesWithEndings};
 use tokio::time::sleep;
 
 #[derive(Debug, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,17 +186,17 @@ async fn main() {
                 panic!("Invalid model");
             }
         },
-        Err(e) => String::from("gpt-3.5-turbo"),
+        Err(_e) => String::from("gpt-3.5-turbo"),
     };
 
     let typing_delay: Duration = match env::var("TYPING_DELAY") {
         Ok(value) => match value.parse() {
             Ok(num) => Duration::from_millis(num),
-            Err(e) => {
+            Err(_e) => {
                 panic!("Typing delay must be u32");
             }
         },
-        Err(e) => Duration::from_millis(10),
+        Err(_e) => Duration::from_millis(10),
     };
 
     // Set up the signal handler


### PR DESCRIPTION
Hi @MakisChristou ,

Thank you for nice command line client. 
Been using it since yesterday, so I thought I'd remove some compiler warnings that are displayed with cargo run. 
Maybe good to remove these unused client.rs imports until you implement formatting?
I'll see what I can do as well. Just got into Rust recently. 
Feel free to close this PR if it is not needed. 